### PR TITLE
Optimize code-generation for deoptimizations using LLVM stack-maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,12 @@ rayon = "1.5"
 rand = "0.8.3"
 measure_time = "0.6.0"
 dmasm = { git = "https://github.com/ss220-space/dmasm", rev = "709231411c5a7c41a2f40440aea77b9b6552caa1" }
-inkwell = { git = "https://github.com/TheDan64/inkwell", default-features = false, branch = "master", features = ["llvm12-0", "target-x86"] }
-llvm-sys = "120"
+inkwell = { git = "https://github.com/ss220-space/inkwell", branch = "dmjit", default-features = false, features = ["llvm12-0", "target-x86"] }
+llvm-sys = "120.2.2"
 libc = "0.2.97"
 typed-arena = "2.0.1"
 criterion = { version = "0.3.5", optional = true}
+binrw = "0.8.0"
 
 [dev-dependencies]
 test_common = { path = "test_common" }
@@ -28,6 +29,7 @@ test_common = { path = "test_common" }
 [build-dependencies]
 vergen = "5.1.17"
 anyhow = "1.0.47"
+cc = "1.0.72"
 
 [lib]
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ libc = "0.2.97"
 typed-arena = "2.0.1"
 criterion = { version = "0.3.5", optional = true}
 binrw = "0.8.0"
+num_enum = "0.5.6"
+itertools = "0.10.3"
 
 [dev-dependencies]
 test_common = { path = "test_common" }

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,12 @@ fn main() -> Result<()> {
     }
     //println!("cargo:rustc-cfg=debug_on_call_print");
 
+    cc::Build::new()
+        .include("src/")
+        .file("src/sectionMemoryManagerBindings.cpp")
+        .cpp(true)
+        .compile("dmjit-cpp");
+
     let mut child = Command::new("llvm-as")
         .arg("src/runtime.ll")
         .arg("-o")

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,12 +1,8 @@
 use std::alloc::{alloc_zeroed, Layout};
-use std::collections::HashMap;
-use std::ffi::CStr;
-use auxtools::{Value, Proc};
 use std::cmp::max;
-use std::marker::PhantomPinned;
+use std::ffi::CStr;
+use std::lazy::Lazy;
 use std::mem::transmute_copy;
-use std::pin::Pin;
-use std::ptr::NonNull;
 
 use auxtools::{Proc, Value};
 use auxtools::DMResult;
@@ -25,48 +21,52 @@ use inkwell::values::AnyValue;
 use crate::{ByondProcFunc, chad_hook_by_id, DisassembleEnv, dmir, guard};
 use crate::codegen::CodeGen;
 use crate::dmir::DMIR;
+use crate::proc_meta::{ProcMeta, ProcMetaModuleBuilder};
 use crate::ref_count::generate_ref_count_operations;
-use crate::section_memory_manager_bindings::{SectionMemoryManager, Section};
-use crate::stack_map::{StackMap, StkMapRecord};
+use crate::section_memory_manager_bindings::{Section, SectionMemoryManager};
+use crate::stack_map::{read_stack_map, StackMap};
 use crate::variable_termination_pass::variable_termination_pass;
 
 #[hook("/proc/dmjit_compile_proc")]
 pub fn compile_and_call(proc_name: auxtools::Value) -> DMResult {
     guard(|| {
-        LLVM_CONTEXT.with(|val| {
-            let mut override_id = 0;
-            let base_proc = match proc_name.raw.tag {
-                ValueTag::String => {
-                    Proc::find(proc_name.as_string().unwrap())
-                }
-                ValueTag::ProcId => {
-                    Proc::from_id(ProcId(unsafe { proc_name.raw.data.id }))
-                }
-                _ => Option::None
-            };
+        let context = unsafe { &mut LLVM_CONTEXT };
+        let module_context = unsafe { &mut LLVM_MODULE_CONTEXT };
+        let module_context = module_context.get_or_insert_with(|| ModuleContext::new(context));
 
-            let name = if let Some(base_proc) = base_proc {
-                base_proc.path
-            } else {
-                return
-            };
-
-            loop {
-                if let Some(proc) = Proc::find_override(&name, override_id) {
-                    compile_proc(
-                        unsafe { val.context_ref.as_ref() },
-                        val.module.as_ref().unwrap(),
-                        val.execution_engine.as_ref().unwrap(),
-                        proc
-                    );
-                    override_id += 1;
-                } else {
-                    break
-                }
+        let mut override_id = 0;
+        let base_proc = match proc_name.raw.tag {
+            ValueTag::String => {
+                Proc::find(proc_name.as_string().unwrap())
             }
-        });
+            ValueTag::ProcId => {
+                Proc::from_id(ProcId(unsafe { proc_name.raw.data.id }))
+            }
+            _ => Option::None
+        };
 
-        DMResult::Ok(Value::null())
+        let name = if let Some(base_proc) = base_proc {
+            base_proc.path
+        } else {
+            return DMResult::Ok(Value::from(false))
+        };
+
+        loop {
+            if let Some(proc) = Proc::find_override(&name, override_id) {
+                compile_proc(
+                    context,
+                    &module_context.module,
+                    &module_context.execution_engine,
+                    &mut module_context.meta_module,
+                    proc,
+                );
+                override_id += 1;
+            } else {
+                break;
+            }
+        }
+
+        DMResult::Ok(Value::from(true))
     })
 }
 
@@ -75,124 +75,93 @@ pub fn compile_and_call(proc_name: auxtools::Value) -> DMResult {
 pub fn install_hooks() -> DMResult {
     guard(|| {
         let mut installed: Vec<String> = vec!();
-        LLVM_CONTEXT.with(|val| {
-            let execution_engine = val.execution_engine.as_ref().unwrap();
-            let module = val.module.as_ref().unwrap();
+        let module_context = unsafe { &mut LLVM_MODULE_CONTEXT };
+        if module_context.is_none() {
+            return DMResult::Ok(Value::from(false))
+        }
+        let module_context = module_context.as_mut().unwrap();
 
-            let mpm = PassManager::create(());
+        let execution_engine = &module_context.execution_engine;
+        let module = &module_context.module;
 
-            mpm.add_always_inliner_pass();
-            mpm.run_on(module);
+        let mpm = PassManager::create(());
 
-            log::info!("Module {}", module.print_to_string().to_string());
+        mpm.add_always_inliner_pass();
+        mpm.run_on(module);
 
-            let mut curr_function = module.get_first_function();
-            while curr_function.is_some() {
-                if let Some(func_value) = curr_function {
-                    let name = func_value.get_name().to_str().unwrap();
+        log::info!("Module {}", module.print_to_string().to_string());
 
-                    if !name.starts_with("<intrinsic>/") && !name.starts_with("dmir.intrinsic") && func_value.get_intrinsic_id() == 0 {
-                        log::info!("installing {}", name);
-                        installed.push(name.to_string());
-                        let func: ByondProcFunc = unsafe {
-                            transmute_copy(&execution_engine.get_function_address(name).unwrap())
-                        };
+        let mut curr_function = module.get_first_function();
+        while curr_function.is_some() {
+            if let Some(func_value) = curr_function {
+                let name = func_value.get_name().to_str().unwrap();
 
-                        log::info!("target is {} at {:?}", name, func as (*mut ()));
+                if !name.starts_with("<intrinsic>/") && !name.starts_with("dmir.intrinsic") && func_value.get_intrinsic_id() == 0 {
+                    log::info!("installing {}", name);
+                    installed.push(name.to_string());
+                    let func: ByondProcFunc = unsafe {
+                        transmute_copy(&execution_engine.get_function_address(name).unwrap())
+                    };
 
-                        let proc_id_attrib = func_value.get_string_attribute(AttributeLoc::Function, "proc_id").unwrap();
-                        // TODO: cleanup
-                        let proc_id = auxtools::raw_types::procs::ProcId(proc_id_attrib.get_string_value().to_string_lossy().parse::<u32>().unwrap());
-                        let proc = Proc::from_id(proc_id).unwrap();
-                        chad_hook_by_id(proc.id, func);
-                    }
+                    log::info!("target is {} at {:?}", name, func as (*mut ()));
+
+                    let proc_id_attrib = func_value.get_string_attribute(AttributeLoc::Function, "proc_id").unwrap();
+                    // TODO: cleanup
+                    let proc_id = auxtools::raw_types::procs::ProcId(proc_id_attrib.get_string_value().to_string_lossy().parse::<u32>().unwrap());
+                    let proc = Proc::from_id(proc_id).unwrap();
+                    chad_hook_by_id(proc.id, func);
                 }
-
-                curr_function = curr_function.unwrap().get_next_function();
             }
-        });
 
+            curr_function = curr_function.unwrap().get_next_function();
+        }
 
         unsafe {
             log::debug!("StackMap section lookup started");
-            let sect = (*MEM_MANAGER).sections.iter().find(|Section { name, .. }|
+            let stack_map_section = (*MEM_MANAGER).sections.iter().find(|Section { name, .. }|
                 name.as_c_str() == CStr::from_bytes_with_nul_unchecked(".llvm_stackmaps\0".as_bytes())
             );
-            if let Some(section) = sect {
-                log::debug!("StackMap section found: {:?}", section);
 
-                let stack_map = crate::stack_map::read_stack_map(section.address, section.size);
-                log::trace!("StackMap: {:#?}", stack_map);
+            log::debug!("StackMap section: {:?}", stack_map_section);
 
-                let StackMap { constants, map_records, .. } = stack_map;
+            let stack_map = stack_map_section.map(|section| read_stack_map(section.address, section.size));
+            log::trace!("StackMap: {:#?}", stack_map);
 
-                STACK_MAP_INDEX = Option::Some(
-                    StackMapIndex {
-                        constants,
-                        records_by_id: map_records.into_iter().map(|record| (record.id, record)).collect(),
-                    }
-                );
-                log::trace!("StackMapIndex: {:?}", STACK_MAP_INDEX);
-            } else {
-                log::debug!("StackMap section not found");
-            }
+            let mut meta_update = module_context.meta_module.build_update_transaction(stack_map);
+
+            log::trace!("Meta update: {:#?}", meta_update);
+
+            meta_update.commit_transaction_to(&mut PROC_META);
 
             log::debug!("All sections is: {:#?}", *(MEM_MANAGER));
         }
+
 
         Value::from_string(installed.join(", "))
     })
 }
 
-pub(crate) static mut STACK_MAP_INDEX: Option<StackMapIndex> = Option::None;
-
-#[derive(Debug)]
-pub struct StackMapIndex {
-    pub constants: Vec<crate::stack_map::Constant>,
-    pub records_by_id: HashMap<u64, StkMapRecord>
-}
+pub(crate) static mut PROC_META: Vec<ProcMeta> = Vec::new();
 
 struct ModuleContext<'ctx> {
-    context: Context,
-    context_ref: NonNull<Context>,
-    module: Option<Module<'ctx>>,
-    execution_engine: Option<ExecutionEngine<'ctx>>,
-    _pin: PhantomPinned
-}
-
-impl<'ctx> Drop for ModuleContext<'ctx> {
-    fn drop(&mut self) {
-        self.execution_engine = Option::None;
-        self.module = Option::None;
-        drop(self.context_ref);
-    }
+    module: Module<'ctx>,
+    execution_engine: ExecutionEngine<'ctx>,
+    meta_module: ProcMetaModuleBuilder,
 }
 
 
 pub(crate) static mut MEM_MANAGER: *mut SectionMemoryManager = std::ptr::null_mut();
 
-impl ModuleContext<'static> {
-
-    fn new() -> Pin<Box<ModuleContext<'static>>> {
-        let s = ModuleContext {
-            context: Context::create(),
-            context_ref: NonNull::dangling(),
-            module: None,
-            execution_engine: None,
-            _pin: PhantomPinned
-        };
-
-        let mut boxed = Box::pin(s);
-
-        let context_ref = NonNull::from(&boxed.context);
+impl <'a, 'b> ModuleContext<'b> {
+    fn new(context: &'a Context) -> ModuleContext<'b> {
 
         let buf = MemoryBuffer::create_from_memory_range(include_bytes!("../target/runtime.bc"), "runtime.ll");
         let module =
-            unsafe { context_ref.as_ref() }
-                .create_module_from_ir(buf).unwrap();
+            unsafe {
+                &*(context as *const Context)
+            }.create_module_from_ir(buf).unwrap();
 
         module.set_name("dmir");
-
 
         unsafe {
             MEM_MANAGER = alloc_zeroed(Layout::new::<SectionMemoryManager>()).cast();
@@ -204,7 +173,6 @@ impl ModuleContext<'static> {
             SectionMemoryManager::create_mcjit_memory_manager(MEM_MANAGER)
         };
 
-
         let execution_engine =
             module.create_jit_execution_engine_with_options(|opts| {
                 opts.OptLevel = OptimizationLevel::Default as u32;
@@ -213,27 +181,25 @@ impl ModuleContext<'static> {
 
         log::info!("Initialize ModuleContext");
 
-        unsafe {
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
-            let ctx = Pin::get_unchecked_mut(mut_ref);
-            ctx.module = Some(module);
-            ctx.execution_engine = Some(execution_engine);
-            ctx.context_ref = context_ref;
+        ModuleContext {
+            module,
+            execution_engine,
+            meta_module: ProcMetaModuleBuilder::new(),
         }
-
-        boxed
     }
 }
 
-thread_local! {
-    static LLVM_CONTEXT: Pin<Box<ModuleContext<'static>>> = ModuleContext::new()
-}
+
+static mut LLVM_CONTEXT: Lazy<Context> = Lazy::new(|| Context::create());
+static mut LLVM_MODULE_CONTEXT: Option<ModuleContext<'static>> = Option::None;
+
 
 fn compile_proc<'ctx>(
     context: &'static Context,
     module: &'ctx Module<'static>,
     execution_engine: &'ctx ExecutionEngine<'static>,
-    proc: auxtools::Proc
+    meta_module: &mut ProcMetaModuleBuilder,
+    proc: auxtools::Proc,
 ) {
     log::info!("Trying compile {}", proc.path);
 
@@ -278,14 +244,18 @@ fn compile_proc<'ctx>(
     for ir in &irs {
         compute_max_sub_call_arg_count(ir, &mut max_sub_call_arg_count);
     }
+
+    let meta_builder = meta_module.create_meta_builder(proc.id);
+
     // Prepare LLVM internals for code-generation
     let mut code_gen = CodeGen::create(
         context,
         &module,
         context.create_builder(),
         execution_engine,
+        meta_builder,
         proc.parameter_names().len() as u32,
-        proc.local_names().len() as u32
+        proc.local_names().len() as u32,
     );
     code_gen.init_builtins();
 
@@ -332,5 +302,4 @@ fn compile_proc<'ctx>(
 
     let res = fpm.run_on(&func);
     log::info!("OPT -- {}\n{}", res, func.print_to_string().to_string());
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(core_intrinsics)]
 #![feature(once_cell)]
 #![feature(asm)]
+#![feature(naked_functions)]
 
 mod compile;
 pub(crate) mod pads;
@@ -21,11 +22,14 @@ mod tools;
 
 #[cfg(feature = "test_utils")]
 mod test_utils;
+pub(crate) mod stack_map;
+mod section_memory_manager_bindings;
 
 
 #[macro_use]
 extern crate auxtools;
 extern crate log;
+extern crate core;
 
 use std::collections::HashMap;
 use auxtools::{hook, CompileTimeHook, StringRef, raw_types, DMResult, Runtime};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod tools;
 mod test_utils;
 pub(crate) mod stack_map;
 mod section_memory_manager_bindings;
+pub(crate) mod proc_meta;
 
 
 #[macro_use]

--- a/src/pads/deopt.rs
+++ b/src/pads/deopt.rs
@@ -2,14 +2,34 @@ extern crate libc;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt::Debug;
+use std::ops::Shr;
+use std::panic::catch_unwind;
 use auxtools::raw_types::funcs::CURRENT_EXECUTION_CONTEXT;
 use auxtools::raw_types::values::{ValueData, ValueTag, Value};
 use auxtools::raw_types::strings::StringId;
 use auxtools::raw_types::procs::{ExecutionContext, ProcInstance, ProcId};
 use auxtools::sigscan;
+use crate::compile::{STACK_MAP_INDEX, StackMapIndex};
+use crate::stack_map::{LocationType, StkMapRecord};
 
 static mut DO_CALL: Option<extern "cdecl" fn(*mut ProcInstance) -> Value> = Option::None;
 
+pub struct DeoptId(pub u64);
+
+impl DeoptId {
+    pub fn new(proc_id: ProcId, site_id: u32) -> Self {
+        let value: u64 =
+            ((proc_id.0 as u64) << 32) | (site_id as u64);
+        Self(value)
+    }
+    fn proc_id(&self) -> ProcId {
+        ProcId((self.0 >> 32) as u32)
+    }
+    fn site_id(&self) -> u32 {
+        (self.0 & 0xFFFF_FFFF) as u32
+    }
+}
 
 #[cfg(unix)]
 fn do_call_trampoline(proc_instance: *mut ProcInstance) -> Value {
@@ -36,21 +56,218 @@ thread_local! {
     pub static DEOPT_COUNT: RefCell<HashMap<(ProcId, u32), u32>> = RefCell::new(HashMap::new());
 }
 
+#[naked]
 #[no_mangle]
-pub extern "C" fn handle_deopt(
+pub unsafe extern "C" fn handle_deopt_entry() {
+    asm!(
+        "sub esp, 0xc", // realign stack
+        "push esp", // store esp first before messing with stack
+        "push eax",
+        "push edx",
+        "push ecx",
+        "push ebx",
+        "push esi",
+        "push edi",
+        "push ebp",
+        "call {}",
+        "add esp, 0x10", // drop non-restore registers
+        "pop ecx", // restore registers that we have to maintain
+        "pop edx",
+        "pop eax",
+        "pop esp",
+        "add esp, 0xc", // de-align stack back
+        "ret",
+        sym handle_deopt_bridge,
+        options(noreturn)
+    )
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct Frame {
+    ebp: u32,
+    edi: u32,
+    esi: u32,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
+    eax: u32,
+    esp: u32,
+    pad0: [u8; 0xc],
+    ret: u32,
+    id: u64
+}
+
+impl Frame {
+    fn reg_value(&self, number: u16) -> u32 {
+        match number {
+            0 => self.eax,
+            1 => self.ecx,
+            2 => self.edx,
+            3 => self.ebx,
+            4 => panic!("esp not stable"),
+            5 => self.ebp,
+            6 => self.esi,
+            7 => self.edi,
+            _ => panic!("unexpected reg_num: {}", number)
+        }
+    }
+}
+
+
+#[derive(Debug)]
+struct ByondFrame {
+    offset: u32,
+    out: *mut Value,
+    src: Value,
+    test_res: bool,
+    arg_count: u32,
+    args: *mut Value,
+    cache: Value,
+    stack: Vec<Value>,
+    locals: Vec<Value>
+}
+
+impl ByondFrame {
+    unsafe fn new(
+        frame: &Frame,
+        stack_map_index: &StackMapIndex,
+        stack_map_record: &StkMapRecord,
+    ) -> Self {
+        let mut idx = 0;
+        let offset = Self::read_local_as(frame, stack_map_record, &mut idx, stack_map_index);
+        let out = Self::read_local_as(frame, stack_map_record, &mut idx, stack_map_index);
+        let src = Self::read_value(frame, stack_map_record, &mut idx, stack_map_index);
+        let test_res = Self::read_local_as(frame, stack_map_record, &mut idx, stack_map_index);
+        let arg_count = Self::read_local_as(frame, stack_map_record, &mut idx, stack_map_index);
+        let args = Self::read_local_as(frame, stack_map_record, &mut idx, stack_map_index);
+        let cache = Self::read_value(frame, stack_map_record, &mut idx, stack_map_index);
+        let stack = Self::read_value_list(frame, stack_map_record, &mut idx, stack_map_index);
+        let locals = Self::read_value_list(frame, stack_map_record, &mut idx, stack_map_index);
+
+        Self {
+            offset,
+            out,
+            src,
+            test_res,
+            arg_count,
+            args,
+            cache,
+            stack,
+            locals
+        }
+    }
+
+    unsafe fn read_value_list(frame: &Frame, stack_map_record: &StkMapRecord, idx: &mut usize, stack_map_index: &StackMapIndex) -> Vec<Value> {
+        let count: u32 = Self::read_local_as(frame, stack_map_record, idx, stack_map_index);
+        let mut vec = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            vec.push(Self::read_value(frame, stack_map_record, idx, stack_map_index));
+        }
+        vec
+    }
+
+    unsafe fn read_value(frame: &Frame, stack_map_record: &StkMapRecord, idx: &mut usize, stack_map_index: &StackMapIndex) -> Value {
+        let tag = Self::read_local_as::<u8>(frame, stack_map_record, idx, stack_map_index);
+        let value = Self::read_local_as::<u32>(frame, stack_map_record, idx, stack_map_index);
+        Value {
+            tag: std::mem::transmute(tag),
+            data: std::mem::transmute(value)
+        }
+    }
+
+    unsafe fn read_local_as<T: Copy + Sized + Debug>(frame: &Frame, stack_map_record: &StkMapRecord, idx: &mut usize, stack_map_index: &StackMapIndex) -> T {
+        let local = &stack_map_record.locations[*idx];
+        *idx += 1;
+
+        let r = match local.loc_type {
+            LocationType::Register => {
+                let reg = frame.reg_value(local.dwarf_reg_num);
+                let value = reg.shr(local.offset_or_const as u8);
+                *(((&value) as *const u32) as *const T)
+            }
+            LocationType::Direct => {
+                *(local.offset_or_const as *const T)
+            }
+            LocationType::Indirect => {
+                let ptr = (frame.reg_value(local.dwarf_reg_num) as *mut u8).offset(local.offset_or_const as isize);
+                *(ptr as *const T)
+            }
+            LocationType::Constant => {
+                let value = local.offset_or_const;
+                *(((&value) as *const u32) as *const T)
+            }
+            LocationType::ConstantIndex => {
+                let value = stack_map_index.constants[local.offset_or_const as usize].large_const;
+                *(((&value) as *const u64) as *const T)
+            }
+        };
+        log::trace!("{:?} -> {:?}", local, r);
+        return r;
+    }
+}
+
+extern "C" fn handle_deopt_bridge(
+    frame: Frame
+) {
+    log::trace!("Deopt called");
+    let res = catch_unwind(move || {
+        let deopt_id = DeoptId(frame.id);
+        log::trace!("Deopt entry: {:?}, site: {}", deopt_id.proc_id(), deopt_id.site_id());
+
+        log::trace!("Deopt frame: {:?}", frame);
+        let stack_map_index = unsafe { STACK_MAP_INDEX.as_ref().unwrap() };
+        let record = stack_map_index.records_by_id.get(&frame.id).unwrap();
+        log::trace!("Deopt record: {:?}", record);
+        let byond_frame = unsafe { ByondFrame::new(&frame, stack_map_index, record) };
+        log::trace!("Byond Frame: {:?}", byond_frame);
+
+
+
+        handle_deopt_internal(
+            byond_frame.out,
+            deopt_id.proc_id(),
+            2,
+            byond_frame.offset,
+            byond_frame.test_res,
+            byond_frame.stack,
+            byond_frame.cache,
+            byond_frame.src,
+            byond_frame.args,
+            byond_frame.arg_count,
+            byond_frame.locals
+        );
+
+        log::trace!("id: {} ret: {:x} eax: {:x} edx: {:x} ecx: {:x} ebx: {:x} esi: {:x} edi: {:x} ebp: {:x} esp: {:x}",
+            frame.id,
+            frame.ret,
+            frame.eax,
+            frame.edx,
+            frame.ecx,
+            frame.ebx,
+            frame.esi,
+            frame.edi,
+            frame.ebp,
+            frame.esp
+        );
+    });
+    if let Result::Err(e) = res {
+        log::error!("deopt panic: {:?}", e);
+    }
+}
+
+fn handle_deopt_internal(
     out: *mut Value,
     proc_id: ProcId,
     proc_flags: u8,
     offset: u32,
     test_flag: bool,
-    stack: *const Value,
-    stack_size: u32,
+    stack: Vec<Value>,
     cached_datum: Value,
     src: Value,
     args: *const Value,
     args_count: u32,
-    locals: *const Value,
-    locals_count: u32
+    locals: Vec<Value>,
 ) {
     let deopt_count = DEOPT_COUNT.with(|deopt_data| {
         *deopt_data.borrow_mut().entry((proc_id, offset))
@@ -119,7 +336,7 @@ pub extern "C" fn handle_deopt(
             tag: ValueTag::Null,
             data: ValueData {
                 id: 0x0
-            }
+            },
         };
         let mut cached_values = [Value { tag: ValueTag::Null, data: ValueData { id: 0x0 } }; 64];
 
@@ -128,10 +345,10 @@ pub extern "C" fn handle_deopt(
         (*context).cached_values = (&mut cached_values) as *mut Value;
         (*context).dmvalue_ptr_2c = (&mut dmvalue_ptr_2c) as *mut Value;
 
-        (*context).locals = put_to_data_store(&mut (*proc).data_store, locals, locals_count);
-        (*context).stack = put_to_data_store(&mut (*proc).data_store, stack, stack_size);
-        (*context).locals_count = locals_count as u16;
-        (*context).stack_size = stack_size as u16;
+        (*context).locals = put_to_data_store(&mut (*proc).data_store, locals.as_ptr(), locals.len() as u32);
+        (*context).stack = put_to_data_store(&mut (*proc).data_store, stack.as_ptr(), stack.len() as u32);
+        (*context).locals_count = locals.len() as u16;
+        (*context).stack_size = stack.len() as u16;
 
         (*context).iterator_stack = std::ptr::null_mut(); // TODO
 
@@ -183,9 +400,8 @@ pub extern "C" fn handle_deopt(
 unsafe fn put_to_data_store(
     data_store: *mut auxtools::raw_types::procs::ArgAndLocalStore,
     data: *const Value,
-    count: u32
+    count: u32,
 ) -> *mut Value {
-
     let data_size = std::mem::size_of::<Value>() * (count as usize);
 
     let dest: *mut Value;

--- a/src/proc_meta.rs
+++ b/src/proc_meta.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use auxtools::raw_types::procs::ProcId;
+use itertools::{Itertools};
+use crate::dmir::ValueLocation;
+use crate::pads::deopt::{DeoptId, DeoptPointMeta, DeoptPointOrigin};
+use crate::stack_map::{Constant, StackMap, StkMapRecord};
+
+/// Sequential ID for each JIT-ed proc, for efficient storage
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ProcMetaId(pub u32);
+
+impl ProcMetaId {
+    fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+/// Metadata structure used by dmJIT
+#[derive(Debug, Clone)]
+pub struct ProcMeta {
+    pub mid: ProcMetaId,
+    pub proc_id: ProcId,
+    pub deopt_point_map: Box<[Option<DeoptPointMeta>]>,
+}
+
+impl ProcMeta {
+    fn stub() -> Self {
+        Self {
+            mid: ProcMetaId(0),
+            proc_id: ProcId(0),
+            deopt_point_map: vec![].into_boxed_slice()
+        }
+    }
+}
+
+
+/// Intermediate storage
+pub struct ProcMetaModuleBuilder {
+    next_mid: ProcMetaId,
+    meta_builders: Vec<ProcMetaBuilder>,
+}
+
+#[derive(Debug)]
+pub struct ProcMetaUpdateTransaction(Vec<ProcMeta>);
+
+impl ProcMetaUpdateTransaction {
+    /// Commit transaction to storage, rebuilding MID order
+    pub fn commit_transaction_to(&mut self, storage: &mut Vec<ProcMeta>) {
+        for proc_meta in self.0.drain(..) {
+            let target_index = proc_meta.mid.0 as usize;
+            if target_index >= storage.len() {
+                storage.resize(target_index + 1, ProcMeta::stub())
+            }
+            storage[target_index] = proc_meta
+        }
+    }
+}
+
+impl ProcMetaModuleBuilder {
+    pub fn new() -> Self {
+        Self {
+            next_mid: ProcMetaId(0),
+            meta_builders: vec![],
+        }
+    }
+
+    pub fn build_update_transaction(
+        &mut self,
+        stack_map: Option<StackMap>
+    ) -> ProcMetaUpdateTransaction {
+
+        let (record_index, constants) = if let Some(StackMap { map_records, constants, .. }) = stack_map {
+            (map_records.into_iter().map(|record| (DeoptId(record.id), record)).collect::<HashMap<_, _>>(), constants)
+        } else {
+            (HashMap::new(), Vec::new())
+        };
+
+        ProcMetaUpdateTransaction(
+            self.meta_builders.drain(..)
+            .map(|builder| builder.build(&record_index, &constants))
+            .collect_vec()
+        )
+    }
+
+    fn next_mid(&mut self) -> ProcMetaId {
+        let r = self.next_mid.clone();
+        let next = r.clone().next();
+        self.next_mid = next;
+        r
+    }
+
+    pub fn create_meta_builder(&mut self, proc_id: ProcId) -> &mut ProcMetaBuilder {
+        let meta_builder = ProcMetaBuilder {
+            mid: self.next_mid(),
+            proc_id,
+            deopt_points: vec![]
+        };
+
+        self.meta_builders.push(meta_builder);
+        self.meta_builders.last_mut().unwrap()
+    }
+}
+
+
+pub struct ProcMetaBuilder {
+    mid: ProcMetaId,
+    proc_id: ProcId,
+    deopt_points: Vec<DeoptPointOrigin>
+}
+
+impl ProcMetaBuilder {
+    pub fn build(self, stack_map_record_index: &HashMap<DeoptId, StkMapRecord>, constants: &Vec<Constant>) -> ProcMeta {
+        let mid = self.mid;
+        let deopt_points = self.deopt_points.into_iter().enumerate().map(|(idx, deopt_point)| {
+            let deopt_point_id = DeoptId::new(mid.clone(), idx as u32);
+            stack_map_record_index.get(&deopt_point_id).map(|record| DeoptPointMeta::parse_stack_map_record(deopt_point, record, constants))
+        }).collect_vec();
+
+        ProcMeta {
+            mid,
+            proc_id: self.proc_id,
+            deopt_point_map: deopt_points.into_boxed_slice()
+        }
+    }
+
+    pub fn add_deopt_point(&mut self, bytecode_offset: u32, inc_ref_count_locations: &Vec<ValueLocation>) -> DeoptId {
+        let deopt_id = DeoptId::new(self.mid.clone(), self.deopt_points.len() as u32);
+        self.deopt_points.push(
+            DeoptPointOrigin {
+                bytecode_offset,
+                inc_ref_count_locations: inc_ref_count_locations.clone().into_boxed_slice(),
+            }
+        );
+        return deopt_id;
+    }
+}
+
+
+
+
+
+
+
+

--- a/src/sectionMemoryManagerBindings.cpp
+++ b/src/sectionMemoryManagerBindings.cpp
@@ -1,0 +1,45 @@
+#include "sectionMemoryManagerBindings.hpp"
+
+extern "C" {
+
+    llvm::SectionMemoryManager* bnLLVMCreateSectionMemoryManager() {
+        return new llvm::SectionMemoryManager();
+    }
+
+    uint8_t* bnLLVMSectionManagerAllocateCodeSection(
+        llvm::SectionMemoryManager *memoryManager,
+        uintptr_t Size,
+        unsigned Alignment,
+        unsigned SectionID,
+        llvm::StringRef SectionName
+    ) {
+        return memoryManager->allocateCodeSection(
+            Size, Alignment,
+            SectionID, SectionName
+        );
+    }
+
+    uint8_t* bnLLVMSectionManagerAllocateDataSection(
+            llvm::SectionMemoryManager *memoryManager,
+            uintptr_t Size, unsigned Alignment,
+            unsigned SectionID, llvm::StringRef SectionName,
+            bool isReadOnly
+    ) {
+        return memoryManager->allocateDataSection(
+            Size, Alignment,
+            SectionID, SectionName,
+            isReadOnly
+        );
+    }
+
+    bool bnLLVMSectionManagerFinalizeMemory(
+        llvm::SectionMemoryManager *memoryManager,
+        std::string *ErrMsg
+    ) {
+        return memoryManager->finalizeMemory(ErrMsg);
+    }
+
+    void bnLLVMDestroySectionMemoryManager(llvm::SectionMemoryManager* memoryManager) {
+        delete memoryManager;
+    }
+}

--- a/src/sectionMemoryManagerBindings.hpp
+++ b/src/sectionMemoryManagerBindings.hpp
@@ -1,0 +1,26 @@
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+
+extern "C" {
+    llvm::SectionMemoryManager* bnLLVMCreateSectionMemoryManager();
+    uint8_t* bnLLVMSectionManagerAllocateCodeSection(
+        llvm::SectionMemoryManager *memoryManager,
+        uintptr_t Size,
+        unsigned Alignment,
+        unsigned SectionID,
+        llvm::StringRef SectionName
+    );
+
+    uint8_t* bnLLVMSectionManagerAllocateDataSection(
+            llvm::SectionMemoryManager *memoryManager,
+            uintptr_t Size, unsigned Alignment,
+            unsigned SectionID, llvm::StringRef SectionName,
+            bool isReadOnly
+    );
+
+    bool bnLLVMSectionManagerFinalizeMemory(
+        llvm::SectionMemoryManager *memoryManager,
+        std::string *ErrMsg
+    );
+
+    void bnLLVMDestroySectionMemoryManager(llvm::SectionMemoryManager* memoryManager);
+}

--- a/src/section_memory_manager_bindings.rs
+++ b/src/section_memory_manager_bindings.rs
@@ -1,0 +1,149 @@
+use std::ffi::{CStr, CString};
+use libc::c_void;
+use llvm_sys::execution_engine::{LLVMCreateSimpleMCJITMemoryManager, LLVMMCJITMemoryManagerRef};
+use llvm_sys::prelude::LLVMBool;
+
+enum LLVMSectionMemoryManagerOpaque {}
+type LLVMSectionMemoryManagerRef = *mut LLVMSectionMemoryManagerOpaque;
+
+#[allow(non_snake_case)]
+extern "C" {
+    fn bnLLVMCreateSectionMemoryManager() -> LLVMSectionMemoryManagerRef;
+    fn bnLLVMDestroySectionMemoryManager(r: LLVMSectionMemoryManagerRef);
+
+    fn bnLLVMSectionManagerAllocateCodeSection(
+        Opaque: LLVMSectionMemoryManagerRef,
+        Size: ::libc::uintptr_t,
+        Alignment: ::libc::c_uint,
+        SectionID: ::libc::c_uint,
+        SectionName: *const ::libc::c_char,
+    ) -> *mut u8;
+
+    fn bnLLVMSectionManagerAllocateDataSection(
+        Opaque: LLVMSectionMemoryManagerRef,
+        Size: ::libc::uintptr_t,
+        Alignment: ::libc::c_uint,
+        SectionID: ::libc::c_uint,
+        SectionName: *const ::libc::c_char,
+        IsReadOnly: LLVMBool,
+    ) -> *mut u8;
+
+    fn bnLLVMSectionManagerFinalizeMemory(
+        Opaque: LLVMSectionMemoryManagerRef,
+        ErrMsg: *mut *mut ::libc::c_char
+    ) -> LLVMBool;
+}
+
+#[derive(Debug)]
+pub struct SectionMemoryManager {
+    internal_ref: LLVMSectionMemoryManagerRef,
+    pub sections: Vec<Section>
+}
+
+#[derive(Debug)]
+pub struct Section {
+    pub name: CString,
+    pub address: *mut u8,
+    pub size: usize
+}
+
+impl Section {
+    fn new(section_name_cstr: *const libc::c_char, address: *mut u8, size: usize) -> Self {
+        Self {
+            name: unsafe { CString::from(CStr::from_ptr(section_name_cstr)) },
+            address,
+            size
+        }
+    }
+}
+
+impl SectionMemoryManager {
+    pub fn new() -> Self {
+        let internal_ref = unsafe { bnLLVMCreateSectionMemoryManager() };
+        return Self {
+            internal_ref,
+            sections: vec![]
+        }
+    }
+
+    extern "C" fn allocate_code_section(
+        opaque: *mut c_void,
+        size: ::libc::uintptr_t,
+        alignment: ::libc::c_uint,
+        section_id: ::libc::c_uint,
+        section_name: *const ::libc::c_char
+    ) -> *mut u8 {
+        let manager = opaque as *mut SectionMemoryManager;
+        let allocated = unsafe {
+            bnLLVMSectionManagerAllocateCodeSection(
+                (*manager).internal_ref,
+                size,
+                alignment,
+                section_id,
+                section_name
+            )
+        };
+        unsafe { (*manager).sections.push(Section::new(section_name, allocated, size)); }
+        return allocated;
+    }
+
+    extern "C" fn allocate_data_section(
+        opaque: *mut c_void,
+        size: ::libc::uintptr_t,
+        alignment: ::libc::c_uint,
+        section_id: ::libc::c_uint,
+        section_name: *const ::libc::c_char,
+        is_read_only: LLVMBool
+    ) -> *mut u8 {
+        let manager = opaque as *mut SectionMemoryManager;
+        let allocated = unsafe {
+            bnLLVMSectionManagerAllocateDataSection(
+                (*manager).internal_ref,
+                size,
+                alignment,
+                section_id,
+                section_name,
+                is_read_only
+            )
+        };
+        unsafe { (*manager).sections.push(Section::new(section_name, allocated, size)); }
+        return allocated;
+    }
+
+    extern "C" fn finalize_memory(
+        opaque: *mut c_void,
+        err_msg: *mut *mut ::libc::c_char
+    ) -> LLVMBool {
+        let manager = opaque as *mut SectionMemoryManager;
+        return unsafe {
+            bnLLVMSectionManagerFinalizeMemory((*manager).internal_ref, err_msg)
+        }
+    }
+
+    extern "C" fn destroy(opaque: *mut c_void) {
+        let manager = opaque as *mut SectionMemoryManager;
+        unsafe { manager.drop_in_place() }
+    }
+
+
+    pub unsafe fn create_mcjit_memory_manager(manager: *mut SectionMemoryManager) -> LLVMMCJITMemoryManagerRef {
+        LLVMCreateSimpleMCJITMemoryManager(
+            manager as *mut c_void,
+            Self::allocate_code_section,
+            Self::allocate_data_section,
+            Self::finalize_memory,
+            Option::Some(Self::destroy)
+        )
+    }
+}
+
+impl Drop for SectionMemoryManager {
+    fn drop(&mut self) {
+        unsafe {
+            bnLLVMDestroySectionMemoryManager(self.internal_ref);
+            self.internal_ref = std::ptr::null_mut();
+            self.sections.clear()
+        }
+    }
+}
+

--- a/src/stack_map.rs
+++ b/src/stack_map.rs
@@ -1,0 +1,133 @@
+/*
+LLVM Stack-map structure
+
+Header {
+  uint8  : Stack Map Version (current version is 3)
+  uint8  : Reserved (expected to be 0)
+  uint16 : Reserved (expected to be 0)
+}
+uint32 : NumFunctions
+uint32 : NumConstants
+uint32 : NumRecords
+StkSizeRecord[NumFunctions] {
+  uint64 : Function Address
+  uint64 : Stack Size
+  uint64 : Record Count
+}
+Constants[NumConstants] {
+  uint64 : LargeConstant
+}
+StkMapRecord[NumRecords] {
+  uint64 : PatchPoint ID
+  uint32 : Instruction Offset
+  uint16 : Reserved (record flags)
+  uint16 : NumLocations
+  Location[NumLocations] {
+    uint8  : Register | Direct | Indirect | Constant | ConstantIndex
+    uint8  : Reserved (expected to be 0)
+    uint16 : Location Size
+    uint16 : Dwarf RegNum
+    uint16 : Reserved (expected to be 0)
+    int32  : Offset or SmallConstant
+  }
+  uint32 : Padding (only if required to align to 8 byte)
+  uint16 : Padding
+  uint16 : NumLiveOuts
+  LiveOuts[NumLiveOuts]
+    uint16 : Dwarf RegNum
+    uint8  : Reserved
+    uint8  : Size in Bytes
+  }
+  uint32 : Padding (only if required to align to 8 byte)
+}
+ */
+
+use std::io::Cursor;
+use binrw::BinRead;
+
+#[derive(BinRead, Debug)]
+#[br(assert(version == 3))]
+pub struct Header {
+    pub version: u8,
+    _r0: u8, // Reserved
+    _r1: u16 // Reserved
+}
+
+#[derive(BinRead, Debug)]
+pub struct StkSizeRecord {
+    pub address: u64,
+    pub stack_size: u64,
+    pub record_count: u64
+}
+
+#[derive(BinRead, Debug)]
+pub struct Constant {
+    pub large_const: u64
+}
+
+#[derive(BinRead, Debug)]
+pub struct LiveOut {
+    pub dwarf_reg_num: u16,
+    _r0: u8,
+    pub size: u8
+}
+
+
+#[derive(BinRead, Debug)]
+#[repr(u8)]
+#[br(repr = u8)]
+pub enum LocationType {
+    Register = 0x1,
+    Direct = 0x2,
+    Indirect = 0x3,
+    Constant = 0x4,
+    ConstantIndex = 0x5
+}
+
+#[derive(BinRead, Debug)]
+pub struct Location {
+    pub loc_type: LocationType,
+    _r0: u8, // Reserved
+    pub loc_size: u16,
+    pub dwarf_reg_num: u16,
+    _r1: u16, // Reserved
+    pub offset_or_const: u32
+}
+
+#[derive(BinRead, Debug)]
+pub struct StkMapRecord {
+    pub id: u64,
+    pub instruction_offset: u32,
+    _r0: u16, // Reserved
+    _num_locations: u16,
+    #[br(count = _num_locations, align_after = 8)]
+    pub locations: Vec<Location>,
+    _pad1: u16, // Padding
+    _num_live_outs: u16,
+    #[br(count = _num_live_outs, align_after = 8)]
+    pub live_outs: Vec<LiveOut>
+}
+
+#[derive(BinRead, Debug)]
+pub struct StackMap {
+    pub header: Header,
+    _num_functions: u32,
+    _num_constants: u32,
+    _num_records: u32,
+
+    #[br(count = _num_functions)]
+    pub stack_records: Vec<StkSizeRecord>,
+    #[br(count = _num_constants)]
+    pub constants: Vec<Constant>,
+    #[br(count = _num_records)]
+    pub map_records: Vec<StkMapRecord>,
+}
+
+
+/// Read LLVM StackMap from raw memory
+pub fn read_stack_map(address: *const u8, size: usize) -> StackMap {
+    unsafe {
+        let mut cursor: Cursor<&[u8]> = Cursor::new(std::slice::from_raw_parts(address as *const u8, size));
+        StackMap::read(&mut cursor).unwrap()
+    }
+}


### PR DESCRIPTION
Now deopts uses LLVM StackMap feature
This reduces the impact of deopt points on code size

StackMap allows us to dump real variable locations at a given program point,
allowing to read it manually from assigned registers/indirect inside deopt code,
instead of packing values into arrays in deopt-calling code