### PR TITLE
Added GitHub Actions CI

### DIFF
--- a/.github/workflows/linux_build_dmjit.yaml
+++ b/.github/workflows/linux_build_dmjit.yaml
@@ -1,0 +1,76 @@
+name: Build DMJit for Linux [Base]
+on:
+  workflow_call:
+    inputs:
+      byondVersion:
+        description: 'Byond major version, like 514 in 514.1543 version'
+        required: true
+        default: '514'
+        type: string
+      byondBuild:
+        description: 'Byond build version, like 1543 in 514.1543 version'
+        required: true
+        default: '1569'
+        type: string
+
+jobs:
+  repository_owner:
+    runs-on: ubuntu-latest
+    outputs:
+      lower_case: ${{ steps.repoNameToLowerString.outputs.lowercase }}
+    steps:
+      - id: repoNameToLowerString
+        name: Repository name to lower string
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ github.REPOSITORY_OWNER }}
+  build_and_test_dmjit:
+    needs: repository_owner
+    name: Build and test dmJIT
+    runs-on: ubuntu-latest
+    container: 
+      image: ghcr.io/${{ needs.repository_owner.outputs.lower_case }}/dmjit-llvm-rust-linux:main
+      options: --user root
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout auxtools repository
+        uses: actions/checkout@v3
+        with:
+          repository: ss220-space/auxtools
+          ref: dm-jitaux
+          path: auxtools
+      - name: Checkout current repository
+        uses: actions/checkout@v3
+        with:
+          path: dmjit
+      - name: Install zip
+        run: apt-get install zip unzip
+      - name: Download byond
+        uses: suisei-cn/actions-download-file@v1
+        id: downloadfile 
+        with:
+          url: "http://www.byond.com/download/build/${{ inputs.byondVersion }}/${{ inputs.byondVersion }}.${{ inputs.byondBuild }}_byond_linux.zip"
+          target: ./
+      - name: Create byond folder
+        run: mkdir byond
+      - name: Extract byond archive
+        run: unzip ${{ inputs.byondVersion }}.${{ inputs.byondBuild }}_byond_linux.zip
+      - name: Set override
+        run: rustup override set nightly-2021-11-05-i686-unknown-linux-gnu
+        working-directory: ./dmjit
+      - name: Run build
+        run: cargo build
+        working-directory: ./dmjit
+      - name: Run tests
+        run: cargo test
+        working-directory: ./dmjit
+        env:
+          BYOND_PATH: /__w/dmjit/dmjit/byond
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: dmjit-test-output
+          path: dmjit/tests/tmp

--- a/.github/workflows/linux_build_dmjit_auto.yaml
+++ b/.github/workflows/linux_build_dmjit_auto.yaml
@@ -1,0 +1,17 @@
+name: Build DMJit for Linux [Auto]
+
+on:
+  push:
+    branches: ['main']
+  workflow_run:
+    workflows: ["(Linux) Create and push Byond image"]
+    types:
+      - completed
+  
+jobs:
+  call_build_and_test_action:
+    name: Call build and test action
+    uses: ./.github/workflows/linux_build_dmjit.yaml
+    with:
+      byondVersion: '514'
+      byondBuild: '1569'

--- a/.github/workflows/linux_build_dmjit_manual.yaml
+++ b/.github/workflows/linux_build_dmjit_manual.yaml
@@ -1,0 +1,21 @@
+name: Build DMJit for Linux [Manual]
+
+on:
+  workflow_dispatch:
+    inputs:
+      byondVersion:
+        description: 'Byond major version, like 514 in 514.1543 version'     
+        required: true
+        default: '514'
+      byondBuild:
+        description: 'Byond build version, like 1543 in 514.1543 version'     
+        required: true
+        default: '1569'
+  
+jobs:
+  call_build_and_test_action:
+    name: Call build and test action
+    uses: ./.github/workflows/linux_build_dmjit.yaml
+    with:
+      byondVersion: ${{ github.event.inputs.byondVersion }}
+      byondBuild: ${{ github.event.inputs.byondBuild }}

--- a/.github/workflows/linux_build_dmjit_pullrequest.yaml
+++ b/.github/workflows/linux_build_dmjit_pullrequest.yaml
@@ -1,0 +1,23 @@
+name: Build DMJit for Linux [PullRequest]
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  
+jobs:
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          all_of: verified
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+  call_build_and_test_action:
+    name: Call build and test action
+    needs: [check_labels]
+    if: needs.check_labels.result == 'success'
+    uses: ./.github/workflows/linux_build_dmjit.yaml
+    with:
+      byondVersion: '514'
+      byondBuild: '1569'

--- a/.github/workflows/linux_build_llvm.yaml
+++ b/.github/workflows/linux_build_llvm.yaml
@@ -1,0 +1,41 @@
+name: (Linux) Create and push LLVM image
+
+on:
+  workflow_dispatch:
+    inputs:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-LLVM-Linux
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./dockerbuild/ubuntu/llvm/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/linux_build_rust.yaml
+++ b/.github/workflows/linux_build_rust.yaml
@@ -1,0 +1,54 @@
+name: (Linux) Create and push Rust image
+
+on:
+  workflow_run:
+    workflows: ["(Linux) Create and push LLVM image"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-llvm-rust-linux
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - id: repoNameToLowerString
+        name: Repository name to lower string
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ github.REPOSITORY_OWNER }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./dockerbuild/ubuntu/rust/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            REPOSITORY_NAME=ghcr.io/${{ steps.repoNameToLowerString.outputs.lowercase }}
+        env:
+          CARGO_HOME: /github/home/.cargo/bin
+          RUSTUP_HOME: /github/home/.cargo/bin

--- a/.github/workflows/windows_build_dmjit.yaml
+++ b/.github/workflows/windows_build_dmjit.yaml
@@ -1,0 +1,19 @@
+name: Build DMJit for Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+  push:
+    branches: ['main']
+    
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  
+jobs:
+  build-dmjit:
+    name: Stub Job
+    runs-on: windows-latest
+    steps:
+      - name: Not Implemented Yet
+        run: echo Not Implemented Yet

--- a/dockerbuild/ubuntu/llvm/Dockerfile
+++ b/dockerbuild/ubuntu/llvm/Dockerfile
@@ -29,10 +29,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -yy install \
         libtinfo-dev:i386
 
 RUN mkdir -p /work/build
-WORKDIR /work
-ADD llvm-12.0.0.src /work/llvm-src
+RUN mkdir -p /work/llvm-src
+WORKDIR /work/llvm-src
+ADD https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/llvm-13.0.1.src.tar.xz llvm-13.0.1.src.tar.xz
+RUN tar -xvf llvm-13.0.1.src.tar.xz
 
 WORKDIR /work/build
-RUN cmake -DCMAKE_LIBRARY_PATH="/usr/lib/i386-linux-gnu" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_BUILD_32_BITS=ON -DLLVM_BUILD_TESTS=OFF -DLLVM_BUILD_BENCHMARKS=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF ../llvm-src
+RUN cmake -DCMAKE_LIBRARY_PATH="/usr/lib/i386-linux-gnu" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_BUILD_32_BITS=ON -DLLVM_BUILD_TESTS=OFF -DLLVM_BUILD_BENCHMARKS=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF ../llvm-src/llvm-13.0.1.src
 RUN cmake --build . -j 16
 RUN cmake --install .

--- a/dockerbuild/ubuntu/rust/Dockerfile
+++ b/dockerbuild/ubuntu/rust/Dockerfile
@@ -1,4 +1,6 @@
-FROM llvm-12
+ARG REPOSITORY_NAME
+FROM $REPOSITORY_NAME/dmjit-llvm-linux:main
+
 
 RUN apt-get install curl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -6,21 +8,12 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN rustup toolchain install nightly-2021-11-05-i686-unknown-linux-gnu
-
-ADD auxtools /work/auxtools
-ADD dmjit /work/dmjit
-
-
-WORKDIR /work/dmjit
-
 RUN rustup target add i686-unknown-linux-gnu
 RUN rustup override set nightly-2021-11-05-i686-unknown-linux-gnu
 
 RUN cargo search lazy_static
 
 ENV LLVM_SYS_120_PREFIX="/usr/local/"
-
 ENV RUSTFLAGS="-L native=/usr/local/lib"
 
 RUN apt-get install libffi-dev:i386
-RUN cargo build --release --target i686-unknown-linux-gnu

--- a/test_common/src/lib.rs
+++ b/test_common/src/lib.rs
@@ -183,12 +183,19 @@ fn lib_path() -> &'static Path {
     }
 }
 
+#[cfg(unix)]
+fn provide_env(cmd: &mut Command) {
+    let library_path = std::env::var("LD_LIBRARY_PATH").unwrap_or("".to_owned());
+    cmd.env("LD_LIBRARY_PATH", format!("{}/bin:{}", byond_path(), library_path));
+    cmd.env("BYOND_SYSTEM", byond_path());
+}
+
 fn cmd_dm() -> Command {
     if cfg!(target_os = "windows") {
         Command::new(format!("{}\\bin\\dm.exe", byond_path()))
     } else {
-        let mut cmd = Command::new(format!("{}/bin/byondexec", byond_path()));
-        cmd.arg(format!("{}/bin/DreamMaker", byond_path()));
+        let mut cmd = Command::new(format!("{}/bin/DreamMaker", byond_path()));
+        provide_env(&mut cmd);
         cmd
     }
 }
@@ -206,8 +213,8 @@ fn cmd_dreamdaemon() -> Command {
     if cfg!(target_os = "windows") {
         Command::new(format!("{}\\bin\\dreamdaemon.exe", byond_path()))
     } else {
-        let mut cmd = Command::new(format!("{}/bin/byondexec", byond_path()));
-        cmd.arg(format!("{}/bin/DreamDaemon", byond_path()));
+        let mut cmd = Command::new(format!("{}/bin/DreamDaemon", byond_path()));
+        provide_env(&mut cmd);
         cmd
     }
 }


### PR DESCRIPTION
Actions (Linux **only**, Windows action is just stub):
- Build image with LLVM 13.0.1 (may be triggered manual);
- Next: Build image with Rust (may be triggered manual or by LLVM image (re-)builded successful);
- Next: Build DMJit in 3 ways:
1.    Manual, _with specific BYOND version_;
2.    On push commit in main branch or Rust image (re-)builded successful, _with hardcoded BYOND version (514.1569)_;
3.    On pull-request opened, reopened, synchronize, labeled, unlabeled if PR contains "verified" label, _with hardcoded BYOND version (514.1569)_;

p.s. Needs replace in `uses`, `racer396/dmjit` to `ss220-space/dmjit` in` .github/workflows/linux_build_dmjit_auto.yaml`, `.github/workflows/linux_build_dmjit_manual.yaml`, `.github/workflows/linux_build_dmjit_pullrequest.yaml`